### PR TITLE
feat: add catalog service

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Install dependencies and start the service:
 npm install
 npm start
 ```
+
+Once running, browse the OData V4 service at <http://localhost:4004/odata/v4/catalog/> to view authors, books, customers, orders and order items.

--- a/srv/catalog-service.cds
+++ b/srv/catalog-service.cds
@@ -1,0 +1,10 @@
+using { bookshop as db } from '../db/schema';
+
+@protocol: 'odata-v4'
+service CatalogService {
+  entity Authors   as projection on db.Authors;
+  entity Books     as projection on db.Books;
+  entity Customers as projection on db.Customers;
+  entity Orders    as projection on db.Orders;
+  entity OrderItems as projection on db.OrderItems;
+}


### PR DESCRIPTION
## Summary
- expose bookshop entities via CatalogService for unauthenticated viewing
- mark CatalogService as OData v4 so the project can be viewed via OData
- document how to browse the OData service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c32b663483248b18083576fbc1f1