### PR TITLE
fix: remove calculated IDs from schema

### DIFF
--- a/db/schema.cds
+++ b/db/schema.cds
@@ -3,13 +3,13 @@ namespace bookshop;
 using { cuid, managed } from '@sap/cds/common';
 
 entity Authors : managed {
-  key ID : UUID = cuid();
+  key ID : UUID;
   name   : String(100);
   books  : Composition of many Books on books.author = $self;
 }
 
 entity Books : managed {
-  key ID : UUID = cuid();
+  key ID : UUID;
   title  : String(255);
   stock  : Integer;
   price  : Decimal(9,2);
@@ -17,14 +17,14 @@ entity Books : managed {
 }
 
 entity Customers : managed {
-  key ID : UUID = cuid();
+  key ID : UUID;
   name   : String(100);
   email  : String(255);
   orders : Composition of many Orders on orders.customer = $self;
 }
 
 entity Orders : managed {
-  key ID : UUID = cuid();
+  key ID : UUID;
   customer : Association to Customers;
   items  : Composition of many OrderItems on items.parent = $self;
 }


### PR DESCRIPTION
## Summary
- remove default `cuid()` assignments from entity IDs in schema so CDS compiler accepts primary keys

## Testing
- `npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c787dd888324b8fb900e9004b0ba