### PR TITLE
Add admin service and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ A simple CAP project for experimenting with the SAP Cloud Application Programmin
 Mock data for a sample bookshop is available in `db/data` and includes authors, books,
 customers, orders and order items for local viewing and testing.
 
+## Admin UI
+
+An administrative dashboard is available at `/admin/`.  It surfaces the full set of
+catalog entities and requires the `ADMIN` role for service access.
+
 ## Running
 
 Install dependencies and start the service:

--- a/app/admin/index.html
+++ b/app/admin/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Dashboard</title>
+</head>
+<body>
+  <h1>Admin Dashboard</h1>
+  <p>You have high privileges to manage catalog data.</p>
+  <div id="books"></div>
+  <script>
+    async function loadBooks() {
+      const res = await fetch('/odata/v4/admin/Books');
+      if (res.ok) {
+        const data = await res.json();
+        const list = data.value.map(b => `<li>${b.title} (stock: ${b.stock})</li>`).join('');
+        document.getElementById('books').innerHTML = `<h2>Books</h2><ul>${list}</ul>`;
+      } else {
+        document.getElementById('books').textContent = 'Failed to load books';
+      }
+    }
+    loadBooks();
+  </script>
+</body>
+</html>

--- a/srv/admin-service.cds
+++ b/srv/admin-service.cds
@@ -1,0 +1,11 @@
+using { bookshop as db } from '../db/schema';
+
+@protocol: 'odata-v4'
+@requires: 'ADMIN'
+service AdminService {
+  entity Authors   as projection on db.Authors;
+  entity Books     as projection on db.Books;
+  entity Customers as projection on db.Customers;
+  entity Orders    as projection on db.Orders;
+  entity OrderItems as projection on db.OrderItems;
+}


### PR DESCRIPTION
## Summary
- add OData AdminService restricted to `ADMIN` role
- provide simple admin dashboard listing catalog entries
- document admin UI entry point

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890d8f35b788324a2ed1205b277c177