### PR TITLE
feat: add admin fiori app

### DIFF
--- a/app/admin/package.json
+++ b/app/admin/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "admin",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Fiori elements admin app to manage all data",
+  "scripts": {
+    "start": "ui5 serve -o index.html"
+  },
+  "devDependencies": {
+    "@ui5/cli": "^3.3.1"
+  }
+}

--- a/app/admin/ui5.yaml
+++ b/app/admin/ui5.yaml
@@ -1,0 +1,12 @@
+specVersion: "3.0"
+type: application
+metadata:
+  name: admin
+framework:
+  name: SAPUI5
+  version: "1.120.0"
+  libraries:
+    - name: sap.m
+    - name: sap.fe.templates
+    - name: sap.fe.core
+    - name: sap.ui.core

--- a/app/admin/webapp/Component.js
+++ b/app/admin/webapp/Component.js
@@ -1,0 +1,11 @@
+sap.ui.define([
+    "sap/ui/core/UIComponent"
+], function (UIComponent) {
+    "use strict";
+
+    return UIComponent.extend("admin.Component", {
+        metadata: {
+            manifest: "json"
+        }
+    });
+});

--- a/app/admin/webapp/index.html
+++ b/app/admin/webapp/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Admin</title>
+    <script id="sap-ui-bootstrap"
+            src="https://ui5.sap.com/resources/sap-ui-core.js"
+            data-sap-ui-theme="sap_horizon"
+            data-sap-ui-async="true"
+            data-sap-ui-resourceroots='{"admin": "./"}'
+            data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
+            data-sap-ui-libs="sap.m,sap.fe.templates"></script>
+</head>
+<body class="sapUiBody" id="content">
+    <div data-sap-ui-component data-name="admin" data-id="container" data-settings='{"id":"admin"}'></div>
+</body>
+</html>

--- a/app/admin/webapp/manifest.json
+++ b/app/admin/webapp/manifest.json
@@ -1,0 +1,164 @@
+{
+  "_version": "1.58.0",
+  "sap.app": {
+    "id": "admin",
+    "type": "application",
+    "title": "Admin",
+    "dataSources": {
+      "mainService": {
+        "uri": "/admin/",
+        "type": "OData",
+        "settings": {
+          "odataVersion": "4.0"
+        }
+      }
+    },
+    "mainService": "mainService"
+  },
+  "sap.ui5": {
+    "dependencies": {
+      "minUI5Version": "1.120.0",
+      "libs": {
+        "sap.m": {},
+        "sap.fe.templates": {},
+        "sap.fe.core": {},
+        "sap.ui.core": {}
+      }
+    },
+    "models": {
+      "": {
+        "dataSource": "mainService",
+        "preload": true,
+        "settings": {
+          "odataVersion": "4.0"
+        }
+      }
+    },
+    "routing": {
+      "routes": [
+        {
+          "pattern": "",
+          "name": "AuthorsList",
+          "target": "AuthorsList"
+        },
+        {
+          "pattern": "Authors({key}):?query:",
+          "name": "AuthorsObjectPage",
+          "target": "AuthorsObjectPage"
+        },
+        {
+          "pattern": "Books",
+          "name": "BooksList",
+          "target": "BooksList"
+        },
+        {
+          "pattern": "Books({key}):?query:",
+          "name": "BooksObjectPage",
+          "target": "BooksObjectPage"
+        },
+        {
+          "pattern": "Customers",
+          "name": "CustomersList",
+          "target": "CustomersList"
+        },
+        {
+          "pattern": "Customers({key}):?query:",
+          "name": "CustomersObjectPage",
+          "target": "CustomersObjectPage"
+        },
+        {
+          "pattern": "Orders",
+          "name": "OrdersList",
+          "target": "OrdersList"
+        },
+        {
+          "pattern": "Orders({key}):?query:",
+          "name": "OrdersObjectPage",
+          "target": "OrdersObjectPage"
+        }
+      ],
+      "targets": {
+        "AuthorsList": {
+          "type": "Component",
+          "id": "AuthorsList",
+          "name": "sap.fe.templates.ListReport",
+          "options": {
+            "settings": {
+              "entitySet": "Authors"
+            }
+          }
+        },
+        "AuthorsObjectPage": {
+          "type": "Component",
+          "id": "AuthorsObjectPage",
+          "name": "sap.fe.templates.ObjectPage",
+          "options": {
+            "settings": {
+              "entitySet": "Authors"
+            }
+          }
+        },
+        "BooksList": {
+          "type": "Component",
+          "id": "BooksList",
+          "name": "sap.fe.templates.ListReport",
+          "options": {
+            "settings": {
+              "entitySet": "Books"
+            }
+          }
+        },
+        "BooksObjectPage": {
+          "type": "Component",
+          "id": "BooksObjectPage",
+          "name": "sap.fe.templates.ObjectPage",
+          "options": {
+            "settings": {
+              "entitySet": "Books"
+            }
+          }
+        },
+        "CustomersList": {
+          "type": "Component",
+          "id": "CustomersList",
+          "name": "sap.fe.templates.ListReport",
+          "options": {
+            "settings": {
+              "entitySet": "Customers"
+            }
+          }
+        },
+        "CustomersObjectPage": {
+          "type": "Component",
+          "id": "CustomersObjectPage",
+          "name": "sap.fe.templates.ObjectPage",
+          "options": {
+            "settings": {
+              "entitySet": "Customers"
+            }
+          }
+        },
+        "OrdersList": {
+          "type": "Component",
+          "id": "OrdersList",
+          "name": "sap.fe.templates.ListReport",
+          "options": {
+            "settings": {
+              "entitySet": "Orders"
+            }
+          }
+        },
+        "OrdersObjectPage": {
+          "type": "Component",
+          "id": "OrdersObjectPage",
+          "name": "sap.fe.templates.ObjectPage",
+          "options": {
+            "settings": {
+              "entitySet": "Orders"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/srv/admin-service.cds
+++ b/srv/admin-service.cds
@@ -1,0 +1,10 @@
+using { bookshop as db } from '../db/schema';
+
+@protocol: 'odata-v4'
+service AdminService {
+  entity Authors   as projection on db.Authors;
+  entity Books     as projection on db.Books;
+  entity Customers as projection on db.Customers;
+  entity Orders    as projection on db.Orders;
+  entity OrderItems as projection on db.OrderItems;
+}


### PR DESCRIPTION
## Summary
- add SAP Fiori elements admin application for managing Authors, Books, Customers and Orders
- expose OData CatalogService without extra admin authentication
- route the admin UI to the new AdminService endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890dd302890832499407c6acdbc07b9