### PR TITLE
feat: attempt to show authors in admin app

### DIFF
--- a/app/admin/webapp/manifest.json
+++ b/app/admin/webapp/manifest.json
@@ -84,7 +84,8 @@
           "name": "sap.fe.templates.ListReport",
           "options": {
             "settings": {
-              "entitySet": "Authors"
+              "entitySet": "Authors",
+              "autoBindOnInit": true
             }
           }
         },

--- a/srv/admin-service.cds
+++ b/srv/admin-service.cds
@@ -8,3 +8,8 @@ service AdminService {
   entity Orders    as projection on db.Orders;
   entity OrderItems as projection on db.OrderItems;
 }
+
+annotate AdminService.Authors with @UI.LineItem: [
+  { Value: ID },
+  { Value: name }
+];

--- a/test/admin-ui.test.js
+++ b/test/admin-ui.test.js
@@ -3,16 +3,32 @@ const assert = require('node:assert/strict');
 const cds = require('@sap/cds');
 const { chromium } = require('playwright');
 
-test('Admin UI renders list report', async () => {
+const fs = require('node:fs');
+
+test('Admin UI renders authors list with data', async () => {
   const srv = await cds.test(__dirname + '/..');
   const browser = await chromium.launch({ args: ['--ignore-certificate-errors'] });
   const context = await browser.newContext({ locale: 'en-US' });
   const page = await context.newPage();
   await page.goto(`${srv.url}/admin/webapp/index.html`, { waitUntil: 'networkidle' });
+
   // allow UI to settle
   await page.waitForTimeout(1000);
-  const text = await page.evaluate(() => document.body.innerText);
-  assert.match(text, /Add columns to see the\s+content/);
+
+  // ensure data is loaded
+  const goButton = page.getByRole('button', { name: 'Go' });
+  await goButton.click({ force: true });
+
+  // ensure folder for screenshots exists
+  fs.mkdirSync('test-results', { recursive: true });
+
+  // wait for author data to appear
+  await page.waitForSelector('text=Primo Levi', { timeout: 10000 });
+  await page.screenshot({ path: 'test-results/admin-authors-list.png', fullPage: true });
+
+  const text = await page.locator('body').innerText();
+  assert.match(text, /Primo Levi/);
+
   await browser.close();
   await srv.server.close();
 });


### PR DESCRIPTION
## Summary
- add UI annotations to AdminService Authors entity
- configure ListReport to auto bind on init and load data
- add Playwright test capturing screenshot for author list

## Testing
- `node --test test/admin-ui.test.js` *(fails: The input did not match /Primo Levi/ or Timeout waiting for Go button)*

------
https://chatgpt.com/codex/tasks/task_e_6891c830e4188324bb9e19cc32765419