### PR TITLE
feat: add book management in admin app

### DIFF
--- a/app/admin/webapp/Component.js
+++ b/app/admin/webapp/Component.js
@@ -10,6 +10,7 @@ sap.ui.define([
 
     init: function() {
       UIComponent.prototype.init.apply(this, arguments);
+      this.getRouter().initialize();
     }
   });
 });

--- a/app/admin/webapp/controller/Book.controller.js
+++ b/app/admin/webapp/controller/Book.controller.js
@@ -1,0 +1,47 @@
+sap.ui.define([
+  "sap/ui/core/mvc/Controller"
+], function(Controller) {
+  "use strict";
+
+  return Controller.extend("admin.controller.Book", {
+    onInit: function() {
+      const oRouter = this.getOwnerComponent().getRouter();
+      oRouter.getRoute("bookDetail").attachPatternMatched(this._onObjectMatched, this);
+      oRouter.getRoute("bookCreate").attachPatternMatched(this._onCreateMatched, this);
+    },
+
+    _onObjectMatched: function(oEvent) {
+      const id = oEvent.getParameter("arguments").ID;
+      this.getView().bindElement({ path: `/Books(${id})` });
+    },
+
+    _onCreateMatched: function() {
+      const oModel = this.getView().getModel();
+      const oListBinding = oModel.bindList("/Books");
+      const oContext = oListBinding.create();
+      this.getView().setBindingContext(oContext);
+    },
+
+    onSave: function() {
+      this.getView().getModel().submitBatch("$auto").then(() => {
+        this.onNavBack();
+      });
+    },
+
+    onDelete: function() {
+      const oContext = this.getView().getBindingContext();
+      if (oContext) {
+        oContext.delete("$auto").then(() => {
+          this.getView().getModel().submitBatch("$auto").then(() => {
+            this.onNavBack();
+          });
+        });
+      }
+    },
+
+    onNavBack: function() {
+      this.getOwnerComponent().getRouter().navTo("main");
+    }
+  });
+});
+

--- a/app/admin/webapp/controller/Main.controller.js
+++ b/app/admin/webapp/controller/Main.controller.js
@@ -6,6 +6,15 @@ sap.ui.define([
   return Controller.extend("admin.controller.Main", {
     onSave: function() {
       this.getView().getModel().submitBatch("$auto");
+    },
+
+    onBookPress: function(oEvent) {
+      const id = oEvent.getSource().getBindingContext().getProperty("ID");
+      this.getOwnerComponent().getRouter().navTo("bookDetail", { ID: id });
+    },
+
+    onAddBook: function() {
+      this.getOwnerComponent().getRouter().navTo("bookCreate");
     }
   });
 });

--- a/app/admin/webapp/i18n/i18n.properties
+++ b/app/admin/webapp/i18n/i18n.properties
@@ -13,3 +13,7 @@ statusNew=New
 statusProcessing=Processing
 statusShipped=Shipped
 statusCancelled=Cancelled
+add=Add
+delete=Delete
+bookDetailTitle=Book
+price=Price

--- a/app/admin/webapp/index.html
+++ b/app/admin/webapp/index.html
@@ -7,7 +7,7 @@
             src="https://ui5.sap.com/resources/sap-ui-core.js"
             data-sap-ui-theme="sap_horizon"
             data-sap-ui-async="true"
-            data-sap-ui-libs="sap.m"
+            data-sap-ui-libs="sap.m,sap.ui.layout"
             data-sap-ui-resourceroots='{"admin": "./"}'>
     </script>
     <script>

--- a/app/admin/webapp/manifest.json
+++ b/app/admin/webapp/manifest.json
@@ -21,7 +21,8 @@
     "dependencies": {
       "minUI5Version": "1.120.0",
       "libs": {
-        "sap.m": {}
+        "sap.m": {},
+        "sap.ui.layout": {}
       }
     },
     "models": {
@@ -42,10 +43,47 @@
       }
     },
     "rootView": {
-      "viewName": "admin.view.Main",
+      "viewName": "admin.view.App",
       "type": "XML",
       "async": true,
-      "id": "main"
+      "id": "app"
+    },
+    "routing": {
+      "config": {
+        "routerClass": "sap.m.routing.Router",
+        "viewType": "XML",
+        "viewPath": "admin.view",
+        "controlId": "app",
+        "controlAggregation": "pages",
+        "async": true
+      },
+      "routes": [
+        {
+          "pattern": "",
+          "name": "main",
+          "target": "Main"
+        },
+        {
+          "pattern": "Books/{ID}",
+          "name": "bookDetail",
+          "target": "Book"
+        },
+        {
+          "pattern": "Books/create",
+          "name": "bookCreate",
+          "target": "Book"
+        }
+      ],
+      "targets": {
+        "Main": {
+          "viewName": "Main"
+        },
+        "Book": {
+          "viewName": "Book",
+          "viewId": "book"
+        }
+      }
     }
   }
 }
+

--- a/app/admin/webapp/view/App.view.xml
+++ b/app/admin/webapp/view/App.view.xml
@@ -1,0 +1,7 @@
+<mvc:View
+  xmlns:mvc="sap.ui.core.mvc"
+  xmlns="sap.m"
+>
+  <App id="app" />
+</mvc:View>
+

--- a/app/admin/webapp/view/Book.view.xml
+++ b/app/admin/webapp/view/Book.view.xml
@@ -1,0 +1,29 @@
+<mvc:View
+  controllerName="admin.controller.Book"
+  xmlns:mvc="sap.ui.core.mvc"
+  xmlns="sap.m"
+  xmlns:form="sap.ui.layout.form"
+>
+  <Page title="{i18n>bookDetailTitle}" showNavButton="true" navButtonPress=".onNavBack">
+    <content>
+      <form:SimpleForm id="form" editable="true">
+        <Label text="ID"/>
+        <Text text="{ID}"/>
+        <Label text="{i18n>titleColumn}"/>
+        <Input value="{title}"/>
+        <Label text="{i18n>stock}"/>
+        <Input value="{stock}" type="Number"/>
+        <Label text="{i18n>price}"/>
+        <Input value="{price}" type="Number"/>
+      </form:SimpleForm>
+    </content>
+    <footer>
+      <Toolbar>
+        <ToolbarSpacer/>
+        <Button text="{i18n>save}" press=".onSave"/>
+        <Button text="{i18n>delete}" type="Reject" press=".onDelete"/>
+      </Toolbar>
+    </footer>
+  </Page>
+</mvc:View>
+

--- a/app/admin/webapp/view/Main.view.xml
+++ b/app/admin/webapp/view/Main.view.xml
@@ -3,15 +3,13 @@
   xmlns:mvc="sap.ui.core.mvc"
   xmlns="sap.m"
   xmlns:core="sap.ui.core">
-  <App id="app">
-    <pages>
-      <Page title="{i18n>title}">
-        <headerContent>
-          <Button text="{i18n>save}" press=".onSave" />
-        </headerContent>
-        <content>
-          <IconTabBar expandable="false">
-            <items>
+  <Page title="{i18n>title}">
+    <headerContent>
+      <Button text="{i18n>save}" press=".onSave" />
+    </headerContent>
+    <content>
+      <IconTabBar expandable="false">
+        <items>
               <IconTabFilter text="{i18n>authors}" key="authors">
                 <Table items="{/Authors}">
                   <columns>
@@ -29,14 +27,21 @@
                 </Table>
               </IconTabFilter>
               <IconTabFilter text="{i18n>books}" key="books">
-                <Table items="{/Books}">
+                <Table id="booksTable" items="{/Books}">
+                  <headerToolbar>
+                    <Toolbar>
+                      <Title text="{i18n>books}"/>
+                      <ToolbarSpacer/>
+                      <Button icon="sap-icon://add" tooltip="{i18n>add}" press=".onAddBook"/>
+                    </Toolbar>
+                  </headerToolbar>
                   <columns>
                     <Column><Text text="ID"/></Column>
                     <Column><Text text="{i18n>titleColumn}"/></Column>
                     <Column><Text text="{i18n>stock}"/></Column>
                   </columns>
                   <items>
-                    <ColumnListItem>
+                    <ColumnListItem type="Navigation" press=".onBookPress">
                       <cells>
                         <Text text="{ID}"/>
                         <Text text="{title}"/>
@@ -91,6 +96,4 @@
           </IconTabBar>
         </content>
       </Page>
-    </pages>
-  </App>
 </mvc:View>


### PR DESCRIPTION
## Summary
- enable routing in admin app with dedicated root view
- add books CRUD UI with list and detail pages
- wire up translations and bootstrap libs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891f612832c8324820c36ec31e595ce