### PR TITLE
feat: add books fe app

### DIFF
--- a/app/books/package.json
+++ b/app/books/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "books",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "ui5 serve -o index.html"
+  },
+  "devDependencies": {
+    "@ui5/cli": "^3"
+  }
+}

--- a/app/books/webapp/Component.js
+++ b/app/books/webapp/Component.js
@@ -1,0 +1,8 @@
+sap.ui.define(["sap/fe/core/AppComponent"], function(AppComponent) {
+    "use strict";
+    return AppComponent.extend("books.Component", {
+        metadata: {
+            manifest: "json"
+        }
+    });
+});

--- a/app/books/webapp/annotations/annotations.xml
+++ b/app/books/webapp/annotations/annotations.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+  <edmx:Reference Uri="https://sapui5.hana.ondemand.com/test-resources/sap/ui/core/sample/common/metadata/edm14_metadata.xml">
+    <edmx:Include Namespace="BooksService" />
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema Namespace="BooksService">
+      <Annotations Target="BooksService.Books">
+        <Annotation Term="UI.LineItem">
+          <Collection>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="ID"/>
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Label" String="{i18n>title}"/>
+              <PropertyValue Property="Value" Path="title"/>
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Label" String="{i18n>author}"/>
+              <PropertyValue Property="Value" Path="author"/>
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.Facets">
+          <Collection>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="{i18n>generalFacet}"/>
+              <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#General"/>
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.FieldGroup" Qualifier="General">
+          <Record>
+            <PropertyValue Property="Data">
+              <Collection>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Label" String="{i18n>title}"/>
+                  <PropertyValue Property="Value" Path="title"/>
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Label" String="{i18n>author}"/>
+                  <PropertyValue Property="Value" Path="author"/>
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/app/books/webapp/annotations/annotations.xml
+++ b/app/books/webapp/annotations/annotations.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" xmlns="http://docs.oasis-open.org/odata/ns/edm">
-  <edmx:Reference Uri="https://sapui5.hana.ondemand.com/test-resources/sap/ui/core/sample/common/metadata/edm14_metadata.xml">
-    <edmx:Include Namespace="BooksService" />
+  <edmx:Reference Uri="../localService/metadata.json">
+    <edmx:Include Namespace="CatalogService" />
   </edmx:Reference>
   <edmx:DataServices>
-    <Schema Namespace="BooksService">
-      <Annotations Target="BooksService.Books">
+    <Schema Namespace="CatalogService">
+      <Annotations Target="CatalogService.Books">
         <Annotation Term="UI.LineItem">
           <Collection>
             <Record Type="UI.DataField">
@@ -17,7 +17,7 @@
             </Record>
             <Record Type="UI.DataField">
               <PropertyValue Property="Label" String="{i18n>author}"/>
-              <PropertyValue Property="Value" Path="author"/>
+              <PropertyValue Property="Value" Path="author/name"/>
             </Record>
           </Collection>
         </Annotation>
@@ -39,7 +39,7 @@
                 </Record>
                 <Record Type="UI.DataField">
                   <PropertyValue Property="Label" String="{i18n>author}"/>
-                  <PropertyValue Property="Value" Path="author"/>
+                  <PropertyValue Property="Value" Path="author/name"/>
                 </Record>
               </Collection>
             </PropertyValue>

--- a/app/books/webapp/i18n/i18n.properties
+++ b/app/books/webapp/i18n/i18n.properties
@@ -1,0 +1,7 @@
+appTitle=Books Management
+appDescription=Manage books
+booksEntity=Books
+id=ID
+title=Title
+author=Author
+generalFacet=General

--- a/app/books/webapp/index.html
+++ b/app/books/webapp/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Books App</title>
+    <script id="sap-ui-bootstrap"
+            src="https://ui5.sap.com/resources/sap-ui-core.js"
+            data-sap-ui-async="true"
+            data-sap-ui-compatVersion="edge"
+            data-sap-ui-theme="sap_horizon"
+            data-sap-ui-onInit="module:sap/ui/core/ComponentSupport"
+            data-sap-ui-resourceroots='{"books": "./"}'>
+    </script>
+</head>
+<body class="sapUiBody" id="content">
+    <div data-sap-ui-component data-name="books" data-id="container" data-settings='{"id":"books"}'></div>
+</body>
+</html>

--- a/app/books/webapp/localService/metadata.json
+++ b/app/books/webapp/localService/metadata.json
@@ -1,0 +1,17 @@
+{
+  "$Version": "4.0",
+  "$EntityContainer": "BooksService.Container",
+  "BooksService": {
+    "Books": {
+      "$kind": "EntityType",
+      "$Key": ["ID"],
+      "ID": { "$kind": "Property", "$Type": "Edm.Int32", "Nullable": false },
+      "title": { "$kind": "Property", "$Type": "Edm.String" },
+      "author": { "$kind": "Property", "$Type": "Edm.String" }
+    },
+    "Container": {
+      "$kind": "EntityContainer",
+      "Books": { "$Type": "BooksService.Books", "$kind": "EntitySet" }
+    }
+  }
+}

--- a/app/books/webapp/localService/metadata.json
+++ b/app/books/webapp/localService/metadata.json
@@ -1,17 +1,29 @@
 {
   "$Version": "4.0",
-  "$EntityContainer": "BooksService.Container",
-  "BooksService": {
+  "$EntityContainer": "CatalogService.EntityContainer",
+  "CatalogService": {
     "Books": {
       "$kind": "EntityType",
       "$Key": ["ID"],
-      "ID": { "$kind": "Property", "$Type": "Edm.Int32", "Nullable": false },
+      "ID": { "$kind": "Property", "$Type": "Edm.Guid", "Nullable": false },
       "title": { "$kind": "Property", "$Type": "Edm.String" },
-      "author": { "$kind": "Property", "$Type": "Edm.String" }
+      "author_ID": { "$kind": "Property", "$Type": "Edm.Guid" },
+      "author": {
+        "$kind": "NavigationProperty",
+        "$Type": "CatalogService.Authors",
+        "$ReferentialConstraint": { "author_ID": "ID" }
+      }
     },
-    "Container": {
+    "Authors": {
+      "$kind": "EntityType",
+      "$Key": ["ID"],
+      "ID": { "$kind": "Property", "$Type": "Edm.Guid", "Nullable": false },
+      "name": { "$kind": "Property", "$Type": "Edm.String" }
+    },
+    "EntityContainer": {
       "$kind": "EntityContainer",
-      "Books": { "$Type": "BooksService.Books", "$kind": "EntitySet" }
+      "Books": { "$Type": "CatalogService.Books", "$kind": "EntitySet" },
+      "Authors": { "$Type": "CatalogService.Authors", "$kind": "EntitySet" }
     }
   }
 }

--- a/app/books/webapp/manifest.json
+++ b/app/books/webapp/manifest.json
@@ -53,7 +53,8 @@
         "preload": true,
         "settings": {
           "synchronizationMode": "None",
-          "operationMode": "Server"
+          "operationMode": "Server",
+          "autoExpandSelect": true
         }
       }
     },

--- a/app/books/webapp/manifest.json
+++ b/app/books/webapp/manifest.json
@@ -1,0 +1,110 @@
+{
+  "_version": "1.56.0",
+  "sap.app": {
+    "id": "books",
+    "type": "application",
+    "i18n": "i18n/i18n.properties",
+    "applicationVersion": {
+      "version": "1.0.0"
+    },
+    "title": "{{appTitle}}",
+    "description": "{{appDescription}}",
+    "dataSources": {
+      "mainService": {
+        "uri": "/odata/v4/catalog/",
+        "type": "OData",
+        "settings": {
+          "odataVersion": "4.0",
+          "localUri": "localService/metadata.json",
+          "annotations": ["annotation"]
+        }
+      },
+      "annotation": {
+        "type": "ODataAnnotation",
+        "uri": "annotations/annotations.xml",
+        "settings": {
+          "localUri": "annotations/annotations.xml"
+        }
+      }
+    }
+  },
+  "sap.ui5": {
+    "dependencies": {
+      "minUI5Version": "1.120.0",
+      "libs": {
+        "sap.ui.core": {},
+        "sap.m": {},
+        "sap.fe.templates": {}
+      }
+    },
+    "contentDensities": {
+      "compact": true,
+      "cozy": true
+    },
+    "models": {
+      "i18n": {
+        "type": "sap.ui.model.resource.ResourceModel",
+        "settings": {
+          "bundleName": "books.i18n.i18n"
+        }
+      },
+      "": {
+        "dataSource": "mainService",
+        "preload": true,
+        "settings": {
+          "synchronizationMode": "None",
+          "operationMode": "Server"
+        }
+      }
+    },
+    "routing": {
+      "config": {
+        "routerClass": "sap.fe.routing.Router",
+        "controlId": "app",
+        "controlAggregation": "pages",
+        "viewType": "XML"
+      },
+      "routes": [
+        {
+          "name": "BooksList",
+          "pattern": ":?query:",
+          "target": "BooksList"
+        },
+        {
+          "name": "BooksObjectPage",
+          "pattern": "Books({key}):?query:",
+          "target": "BooksObjectPage"
+        }
+      ],
+      "targets": {
+        "BooksList": {
+          "type": "Component",
+          "id": "BooksList",
+          "name": "sap.fe.templates.ListReport",
+          "options": {
+            "settings": {
+              "entitySet": "Books",
+              "variantManagement": "Page",
+              "tableSettings": {
+                "type": "ResponsiveTable",
+                "selectionMode": "Multi",
+                "personalization": true,
+                "enableExport": true
+              }
+            }
+          }
+        },
+        "BooksObjectPage": {
+          "type": "Component",
+          "id": "BooksObjectPage",
+          "name": "sap.fe.templates.ObjectPage",
+          "options": {
+            "settings": {
+              "entitySet": "Books"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Fiori Elements V4 ListReport/ObjectPage app for Books
- enable table personalization, multi-select and Excel export
- add annotations and local metadata with i18n labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895cbd5b63c8324bd3e7c7644316611