### PR TITLE
feat: add German i18n support

### DIFF
--- a/app/project1/webapp/i18n/i18n_de.properties
+++ b/app/project1/webapp/i18n/i18n_de.properties
@@ -1,0 +1,4 @@
+# This is the resource bundle for project1 in German
+#Texts for manifest.json
+appTitle=Buchverwaltung
+appDescription=Eine SAP Fiori Anwendung.

--- a/app/project1/webapp/index.html
+++ b/app/project1/webapp/index.html
@@ -22,6 +22,12 @@
         data-sap-ui-async="true"
         data-sap-ui-frameOptions="trusted"
     ></script>
+    <script>
+        window.addEventListener('load', function () {
+            var bundle = sap.ui.getCore().getLibraryResourceBundle('project1');
+            document.title = bundle.getText('appTitle');
+        });
+    </script>
 </head>
 <body class="sapUiBody sapUiSizeCompact" id="content">
     <div

--- a/app/project1/webapp/test/flpSandbox.html
+++ b/app/project1/webapp/test/flpSandbox.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html lang="en">
+<html>
 <!-- Copyright (c) 2015 SAP AG, All Rights Reserved -->
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -45,8 +45,8 @@
             },
             applications: {
                 "project1-tile": {
-                    title: "Book management",
-                    description: "An SAP Fiori application.",
+                    title: "{{appTitle}}",
+                    description: "{{appDescription}}",
                     additionalInformation: "SAPUI5.Component=project1",
                     applicationType: "URL",
                     url: "../"
@@ -64,13 +64,16 @@
         data-sap-ui-preload="async"
         data-sap-ui-theme="sap_horizon"
         data-sap-ui-compatVersion="edge"
-        data-sap-ui-language="en"
         data-sap-ui-resourceroots='{"project1": "../"}'
         data-sap-ui-frameOptions="allow"
         data-sap-ui-flexibilityServices='[{"connector": "LocalStorageConnector"}]'>
     </script>
     <script>
         sap.ui.getCore().attachInit(function () {
+            var bundle = sap.ui.getCore().getLibraryResourceBundle('project1');
+            var tile = window["sap-ushell-config"].applications["project1-tile"];
+            tile.title = bundle.getText('appTitle');
+            tile.description = bundle.getText('appDescription');
             sap.ushell.Container.createRenderer().placeAt("content");
         });
     </script>

--- a/srv/admin-service.ts
+++ b/srv/admin-service.ts
@@ -35,7 +35,7 @@ export default cds.service.impl(function (this: Service) {
       const { subject, message } = req.data;
       const { ID } = req.params[0] as { ID: string };
       console.log(`Contacting customer ${ID}: ${subject} - ${message}`);
-      return "Message sent";
+      return cds.i18n.messages.at("contact.messageSent", req.user?.locale);
     }
   );
 

--- a/srv/i18n/messages.properties
+++ b/srv/i18n/messages.properties
@@ -1,0 +1,1 @@
+contact.messageSent=Message sent

--- a/srv/i18n/messages_de.properties
+++ b/srv/i18n/messages_de.properties
@@ -1,0 +1,1 @@
+contact.messageSent=Nachricht gesendet

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import cds from '@sap/cds';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const { GET, POST } = cds.test(__dirname + '/..');
+
+test('contact action is localized', async () => {
+  let res = await GET('/odata/v4/admin/Customers?$top=1');
+  assert.equal(res.status, 200);
+  const id = res.data.value[0].ID;
+
+  res = await POST(`/odata/v4/admin/Customers(ID=${id})/contact`, { subject: 'Hi', message: 'Test' }, { headers: { 'Accept-Language': 'de' } });
+  assert.equal(res.status, 200);
+  assert.equal(res.data.value, 'Nachricht gesendet');
+
+  res = await POST(`/odata/v4/admin/Customers(ID=${id})/contact`, { subject: 'Hi', message: 'Test' }, { headers: { 'Accept-Language': 'en' } });
+  assert.equal(res.status, 200);
+  assert.equal(res.data.value, 'Message sent');
+});
+
+test('Fiori app bundles include German translations', () => {
+  const i18nDir = path.join(__dirname, '../app/project1/webapp/i18n');
+  const readProps = (file: string) =>
+    Object.fromEntries(
+      fs
+        .readFileSync(file, 'utf-8')
+        .split(/\r?\n/)
+        .filter((l) => l && !l.startsWith('#'))
+        .map((l) => {
+          const idx = l.indexOf('=');
+          return [l.slice(0, idx), l.slice(idx + 1)];
+        })
+    );
+  const en = readProps(path.join(i18nDir, 'i18n.properties'));
+  const de = readProps(path.join(i18nDir, 'i18n_de.properties'));
+  assert.equal(en.appTitle, 'Book management');
+  assert.equal(de.appTitle, 'Buchverwaltung');
+  assert.equal(de.appDescription, 'Eine SAP Fiori Anwendung.');
+});


### PR DESCRIPTION
## Summary
- add German resource bundle for the Fiori app
- localize `contact` action responses using CAP i18n
- verify translations with new tests
- localize remaining UI titles for launchpad and index page

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_689c5ffee2e483249d38126ab9bc16c5